### PR TITLE
Spout to accept a metric registration function

### DIFF
--- a/tormenta-core/src/main/scala/com/twitter/tormenta/spout/Proxy.scala
+++ b/tormenta-core/src/main/scala/com/twitter/tormenta/spout/Proxy.scala
@@ -32,14 +32,11 @@ trait SpoutProxy extends IRichSpout with Proxied[IRichSpout] with Serializable {
 }
 
 class RichStormSpout(val self: IRichSpout,
-    @transient metrics: List[() => TraversableOnce[Metric[_]]],
-    @transient regFn: (TopologyContext) => Unit) extends SpoutProxy {
-  val lockedMetrics = Externalizer(metrics)
-  val lockedFn = Externalizer(regFn)
+    @transient callOnOpen: (TopologyContext) => Unit) extends SpoutProxy {
+  val lockedFn = Externalizer(callOnOpen)
 
   override def open(conf: JMap[_, _], context: TopologyContext, coll: SpoutOutputCollector) {
-    lockedMetrics.get.foreach(mList => mList().foreach(_.register(context)))
-    self.open(conf, context, coll)
     lockedFn.get(context)
+    self.open(conf, context, coll)
   }
 }

--- a/tormenta-core/src/main/scala/com/twitter/tormenta/spout/SchemeSpout.scala
+++ b/tormenta-core/src/main/scala/com/twitter/tormenta/spout/SchemeSpout.scala
@@ -24,13 +24,11 @@ trait SchemeSpout[+T] extends BaseSpout[T] {
   /**
    * This is the only required override.
    */
-  def getSpout[R](transformer: Scheme[T] => Scheme[R],
-    metrics: List[() => TraversableOnce[Metric[_]]],
-    regFn: TopologyContext => Unit): IRichSpout
+  def getSpout[R](transformer: Scheme[T] => Scheme[R], fn: => TopologyContext => Unit): IRichSpout
 
   override def poll = List()
 
-  override def getSpout = getSpout(identity(_), metricFactory, regFn)
+  override def getSpout = getSpout(identity(_), callOnOpen)
 
   override def flatMap[U](fn: T => TraversableOnce[U]): BaseSpout[U] =
     new FlatMappedSchemeSpout(this)(fn)

--- a/tormenta-core/src/main/scala/com/twitter/tormenta/spout/Spout.scala
+++ b/tormenta-core/src/main/scala/com/twitter/tormenta/spout/Spout.scala
@@ -46,7 +46,7 @@ trait Spout[+T] extends Serializable { self =>
    * Passes metrics to register with storm and a function to run on the storm runtime context
    *  when the spout is opened.
    */
-  def registerMetricHandlers(metrics: () => TraversableOnce[Metric[_]], regFn: TopologyContext => Unit) = self
+  def openHook(fn: => TopologyContext => Unit) = self
 
   def flatMap[U](fn: T => TraversableOnce[U]): Spout[U]
 

--- a/tormenta-kafka/src/main/scala/com/twitter/tormenta/spout/KafkaSpout.scala
+++ b/tormenta-kafka/src/main/scala/com/twitter/tormenta/spout/KafkaSpout.scala
@@ -27,9 +27,7 @@ import backtype.storm.task.TopologyContext
 
 class KafkaSpout[+T](scheme: Scheme[T], zkHost: String, brokerZkPath: String, topic: String, appID: String, zkRoot: String, forceStartOffsetTime: Int = -1)
     extends SchemeSpout[T] {
-  override def getSpout[R](transformer: Scheme[T] => Scheme[R],
-    metrics: List[() => TraversableOnce[Metric[_]]],
-    regFn: TopologyContext => Unit) = {
+  override def getSpout[R](transformer: Scheme[T] => Scheme[R], callOnOpen: => TopologyContext => Unit) = {
     // Spout ID needs to be unique per spout, so create that string by taking the topic and appID.
     val spoutId = topic + appID
     val spoutConfig = new SpoutConfig(new KafkaConfig.ZkHosts(zkHost, brokerZkPath), topic, zkRoot, spoutId)
@@ -37,6 +35,6 @@ class KafkaSpout[+T](scheme: Scheme[T], zkHost: String, brokerZkPath: String, to
     spoutConfig.scheme = transformer(scheme)
     spoutConfig.forceStartOffsetTime(forceStartOffsetTime)
 
-    new RichStormSpout(new StormKafkaSpout(spoutConfig), metrics, regFn)
+    new RichStormSpout(new StormKafkaSpout(spoutConfig), callOnOpen)
   }
 }

--- a/tormenta-kestrel/src/main/scala/com/twitter/tormenta/spout/KestrelSpout.scala
+++ b/tormenta-kestrel/src/main/scala/com/twitter/tormenta/spout/KestrelSpout.scala
@@ -29,7 +29,6 @@ import backtype.storm.task.TopologyContext
 class KestrelSpout[+T](scheme: Scheme[T], hosts: List[String], name: String, port: Int = 2229)
     extends SchemeSpout[T] {
   override def getSpout[R](transformer: Scheme[T] => Scheme[R],
-    metrics: List[() => TraversableOnce[Metric[_]]],
-    regFn: TopologyContext => Unit) =
-    new RichStormSpout(new KestrelThriftSpout(hosts.asJava, port, name, transformer(scheme)), metrics, regFn)
+    callOnOpen: => TopologyContext => Unit) =
+      new RichStormSpout(new KestrelThriftSpout(hosts.asJava, port, name, transformer(scheme)), callOnOpen)
 }


### PR DESCRIPTION
This is needed for Summingbird platform-independent counters to work. We need to pass a function that registers the metrics with the StormStatProvider that the counters use.
