### PR TITLE
use withHandler in map, filter and flatMap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # tormenta #
 
+### Version 0.11.0 ###
+
+* handlers now survive map, filter, flatMap https://github.com/twitter/tormenta/pull/66
+
 ### Version 0.10.0 ###
 * Bumps to upstream versions
 

--- a/tormenta-core/src/main/scala/com/twitter/tormenta/scheme/Scheme.scala
+++ b/tormenta-core/src/main/scala/com/twitter/tormenta/scheme/Scheme.scala
@@ -59,12 +59,15 @@ trait Scheme[+T] extends MultiScheme with Serializable { self =>
 
   def filter(fn: T => Boolean): Scheme[T] =
     Scheme(self.decode(_).filter(fn))
+      .withHandler(self.handle(_).filter(fn))
 
   def map[R](fn: T => R): Scheme[R] =
     Scheme(self.decode(_).map(fn))
+      .withHandler(self.handle(_).map(fn))
 
   def flatMap[R](fn: T => TraversableOnce[R]): Scheme[R] =
     Scheme(self.decode(_).flatMap(fn))
+      .withHandler(self.handle(_).flatMap(fn))
 
   private def cast(t: Any): JList[AnyRef] = new Values(t.asInstanceOf[AnyRef])
   private def toJava(items: TraversableOnce[Any]) =

--- a/tormenta-core/src/test/scala/com/twitter/tormenta/scheme/SchemeLaws.scala
+++ b/tormenta-core/src/test/scala/com/twitter/tormenta/scheme/SchemeLaws.scala
@@ -23,10 +23,14 @@ class SchemeWithHandlerSpecification extends WordSpec with Matchers {
   "Scheme" should {
     val f: Array[Byte] => List[String] = b => throw new IllegalArgumentException("decode failed")
 
-    def checkResult[T](scheme: Scheme[T], expectedResult: T) {
+    def eqv[T, U](t: T, u: U)(implicit ev: U =:= T): Boolean = (t == u)
+
+    def checkResult[T](scheme: Scheme[T], expectedResult: List[T]) {
       val result = scheme.deserialize("test string".getBytes("UTF-8"))
       assert(result.asScala.isEmpty == false) //test fails, returns an empty list
-      assert(result.asScala.toList.map(_.get(0)) == expectedResult)
+      assert {
+        eqv(result.asScala.toList.map(_.get(0).asInstanceOf[T]), expectedResult)
+      }
     }
 
     val schemeWithErrorHandler = Scheme(f).withHandler(t => List(t.getMessage))

--- a/tormenta-core/src/test/scala/com/twitter/tormenta/scheme/SchemeLaws.scala
+++ b/tormenta-core/src/test/scala/com/twitter/tormenta/scheme/SchemeLaws.scala
@@ -19,16 +19,32 @@ package com.twitter.tormenta.scheme
 import org.scalatest._
 import scala.collection.JavaConverters._
 
-object SchemeWithHandlerSpecification extends WordSpec with Matchers {
-  "Scheme should handle failure" should {
-    "test failure" in {
-      val f: Array[Byte] => List[String] = b => throw new IllegalArgumentException("decode failed")
+class SchemeWithHandlerSpecification extends WordSpec with Matchers {
+  "Scheme" should {
+    val f: Array[Byte] => List[String] = b => throw new IllegalArgumentException("decode failed")
 
-      val schemeWithErrorHandler = Scheme(f).withHandler(t => List(t.getMessage))
-      val result = schemeWithErrorHandler.deserialize("test string".getBytes("UTF-8"))
-
+    def checkResult[T](scheme: Scheme[T], expectedResult: T) {
+      val result = scheme.deserialize("test string".getBytes("UTF-8"))
       assert(result.asScala.isEmpty == false) //test fails, returns an empty list
-      assert(result.asScala.head.get(0) == "decode failed")
+      assert(result.asScala.toList.map(_.get(0)) == expectedResult)
+    }
+
+    val schemeWithErrorHandler = Scheme(f).withHandler(t => List(t.getMessage))
+
+    "handle failure" in checkResult(schemeWithErrorHandler, List("decode failed"))
+
+    "map failure" in checkResult(schemeWithErrorHandler.map(_.length), List(13))
+
+    "flatMap failure" in {
+      val scheme = schemeWithErrorHandler.flatMap(s => List(s, s))
+      checkResult(scheme, List("decode failed", "decode failed"))
+    }
+
+    "filter failure" in {
+      val scheme = schemeWithErrorHandler
+        .flatMap(s => List(s, "one"))
+        .filter(_ == "one")
+      checkResult(scheme, List("one"))
     }
   }
 }


### PR DESCRIPTION
Fixes #59. I also noticed that SBT wasn't running the scheme laws! It looks like you have to have a class, not a companion object. I don't remember this behavior, but here's another case of it:

http://stackoverflow.com/questions/24067473/sbt-wont-run-scalatest-tests