### PR TITLE
Add IDEA's project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+
+# IDEA's project files
+/.idea/
+/.idea_modules/
+*.iml


### PR DESCRIPTION
Tormenta uses sbt to define project structure, therefore IDEA related files should be ignored by git.