### PR TITLE
Setting version to 0.12.1-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,11 +120,9 @@ lazy val formattingPreferences = {
 val unreleasedModules = Set[String]()
 
 def youngestForwardCompatible(subProj: String) =
-  None
-// Uncomment after next release
-//  Some(subProj)
-//    .filterNot(unreleasedModules.contains(_))
-//    .map { s => "com.twitter" % ("tormenta-" + s + "_2.10") % "0.11.0" }
+  Some(subProj)
+    .filterNot(unreleasedModules.contains(_))
+    .map { s => "com.twitter" % ("tormenta-" + s + "_2.10") % "0.12.0" }
 
 /**
   * Empty this each time we publish a new version (and bump the minor number)
@@ -133,9 +131,6 @@ val ignoredABIProblems = {
   import com.typesafe.tools.mima.core._
   import com.typesafe.tools.mima.core.ProblemFilters._
   Seq(
-    exclude[ReversedMissingMethodProblem](
-      "com.twitter.tormenta.spout.SchemeSpout.openHook"
-    )
   )
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.0"
+version in ThisBuild := "0.12.1-SNAPSHOT"


### PR DESCRIPTION
We need to set version to 0.12.1-SNAPSHOT, update `youngestForwardCompatible` and empty all mima excludes as 0.12.0 was a major release.